### PR TITLE
fix(ci): add missing permissions to ai-review and secrets-scan jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
   secrets-scan:
     name: Security — Secrets Scan (Gitleaks)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -127,6 +130,10 @@ jobs:
     name: AI — PR Review (Claude)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: anthropics/claude-code-action@beta


### PR DESCRIPTION
## Summary

- `ai-review`: added `id-token: write` (required by `claude-code-action@beta` to fetch OIDC token for GitHub API auth) and `pull-requests: write`
- `secrets-scan`: added `pull-requests: write` so Gitleaks can post PR annotations

## Root cause

`claude-code-action@beta` uses OIDC to get a GitHub token rather than relying on `GITHUB_TOKEN` directly. Without `id-token: write` at the job level, the OIDC request fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`.

## Test plan

- [ ] `ai-review` job completes without OIDC token error
- [ ] `secrets-scan` job completes without 401 on PR annotation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)