### PR TITLE
fix: remove output standalone from next.config.mjs for Vercel

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: "standalone",
-};
+const nextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
output: 'standalone' is for Docker self-hosting. Vercel generates internal config with invalid 'root' property when it sees this, causing schema validation failure.