### PR TITLE
docs(readme): add TA demo walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,50 @@
 
 **AI-powered technical interview preparation platform.** Practice with an AI interviewer that generates role-specific questions, evaluates responses across five dimensions, and delivers actionable behavioral feedback. Coaches audit and override AI scores, building ground-truth data that powers a self-improving LLM-as-judge evaluation system.
 
-> Course project — CS Graduate AI Engineering, Northeastern University  
+> Course project — CS Graduate AI Engineering, Northeastern University
 > Authors: Xuan Bai, Dhruv Gorasiya
+
+---
+
+## For Reviewers / TAs — Quick Demo Walkthrough
+
+This project has **two user roles** (Candidate and Coach). You will need to create one of each to exercise the full flow. Everything below assumes the backend is on `http://localhost:8000` and the frontend on `http://localhost:3000`.
+
+### 1. Create a Candidate account
+
+1. Open **http://localhost:3000/register**
+2. Enter any email + a password with at least 8 characters, one uppercase letter, and one digit (e.g. `Candidate1`)
+3. Submit → you are auto-logged-in and land on **`/dashboard`** (the candidate dashboard)
+4. Click **New Session**, pick an interview type (behavioral / technical / system design) and a role (SWE / PM / DS), and start
+5. Answer each question → the session transitions to `completed` once all questions are answered
+
+### 2. Create a Coach account (no SQL required)
+
+> Coach registration is gated by a query parameter instead of a separate form — it keeps the UI simple while still letting reviewers create coach accounts without touching the database.
+
+1. Open **http://localhost:3000/register?role=coach**
+2. You should see a **purple "Registering as Coach" badge** next to the page heading — this confirms the role parameter was picked up
+3. Fill in a different email and the same password rules as above
+4. Submit → you are auto-logged-in and land on **`/review`** (the coach review queue — not the candidate dashboard)
+
+If the purple badge is missing, the URL did not include `?role=coach` and the account will be created as a candidate. Double-check the URL before submitting.
+
+Admin accounts are deliberately **not** creatable via the public register endpoint. `?role=admin` is silently treated as candidate.
+
+### 3. Walk the coach flow
+
+1. Log in as the coach you just created (or stay logged in)
+2. Land on **`/review`** — the queue shows every candidate session whose status is `completed` (not yet `reviewed`)
+3. Click into a session → you see the question, the candidate's answer, the AI scores across all five dimensions, and an override form pre-filled with the AI scores as a starting point
+4. Adjust any dimension score, optionally add a **Justification** explaining the override, and click **Submit score**
+5. Navigate between questions with **Previous / Next** — the form resets per question so nothing leaks between them
+6. The first override flips the session's status from `completed` to `reviewed`, so it drops off the queue. The candidate can still view it from their dashboard — it just no longer needs review.
+
+### 4. Things worth trying
+
+- **Log out and back in** — coaches should always land on `/review`, candidates on `/dashboard`. The post-login redirect is driven by `GET /api/v1/auth/me`.
+- **Stale token** — edit `mockready_access_token` in LocalStorage to a garbage value and refresh. The UI auto-logs-out instead of getting stuck (the `/auth/me` 401 clears the token).
+- **Cross-role URL poking** — as a candidate, navigate to `/review`. The coach layout guard bounces you back to `/login` because the route is role-gated.
 
 ---
 
@@ -14,8 +56,8 @@ MockReady addresses a gap that existing tools like Leetcode, Pramp, and ChatGPT 
 | Role | What They Do |
 |---|---|
 | **Candidate** | Selects a role and interview type, completes a timed session, receives per-dimension AI scores with behavioral feedback |
-| **Coach** | Reviews AI-scored sessions, overrides scores with justification, adds written commentary |
-| **Admin** | Manages the question bank, configures scoring rubrics, monitors AI evaluation accuracy |
+| **Coach** | Reviews AI-scored sessions, overrides scores with justification |
+| **Admin** | (planned) Manages the question bank, configures scoring rubrics, monitors AI evaluation drift |
 
 ---
 
@@ -26,55 +68,18 @@ MockReady addresses a gap that existing tools like Leetcode, Pramp, and ChatGPT 
 | Frontend | Next.js 14 (App Router), TypeScript, Tailwind CSS |
 | Backend | FastAPI (Python 3.11+) |
 | Database | Supabase (PostgreSQL) via SQLAlchemy ORM |
-| AI | Anthropic Claude API (`claude-sonnet-4-20250514`) |
-| Auth | Supabase Auth (JWT) |
-| Testing (BE) | pytest + pytest-asyncio |
-| Testing (FE) | Jest + React Testing Library |
+| AI | Anthropic Claude API (`claude-sonnet-4-6`) |
+| Auth | JWT (HS256), verified against `SUPABASE_JWT_SECRET` |
+| Testing | pytest + pytest-asyncio (backend), Jest + React Testing Library (frontend), Playwright (e2e) |
 | Linting | Ruff (Python), ESLint + Prettier (TypeScript) |
 | Package mgmt | uv (Python), npm (Node) |
 | Deployment | Vercel (frontend) |
 
 ---
+
 ## Architecture Diagram
 
 ![Architecture](docs/architecture.png)
-
-
----
-
-## Repository Structure
-
-```
-/
-├── frontend/                  # Next.js app
-│   ├── app/                   # App Router pages and layouts
-│   │   ├── (candidate)/       # Candidate-facing routes
-│   │   ├── (coach)/           # Coach-facing routes
-│   │   ├── login/
-│   │   └── register/
-│   ├── components/            # Reusable UI components
-│   ├── lib/                   # API client, utilities, types
-│   └── __tests__/             # Jest tests
-├── backend/
-│   ├── app/
-│   │   ├── api/v1/            # Route handlers (auth, sessions, coach, health)
-│   │   ├── agents/            # AI agent modules
-│   │   │   ├── question_generation.py
-│   │   │   ├── answer_evaluation.py
-│   │   │   ├── feedback_synthesis.py
-│   │   │   └── logging_utils.py
-│   │   ├── models/            # SQLAlchemy ORM models
-│   │   ├── schemas/           # Pydantic request/response schemas
-│   │   ├── services/          # Business logic (session, coach, auth)
-│   │   ├── core/              # Config, DB session, security
-│   │   └── tests/             # pytest tests
-│   ├── alembic/               # Database migrations
-│   └── pyproject.toml
-├── docs/                      # Architecture, PRD, sprint notes, security
-├── tasks/                     # todo.md, lessons.md
-├── vercel.json
-└── CLAUDE.md
-```
 
 ---
 
@@ -85,56 +90,63 @@ MockReady addresses a gap that existing tools like Leetcode, Pramp, and ChatGPT 
 - Python 3.11+
 - Node.js 18+
 - [`uv`](https://github.com/astral-sh/uv) for Python package management
-- A Supabase project (for DB and auth)
+- A Supabase project (for the Postgres DB)
 - An Anthropic API key
 
-### Environment Variables
+### Environment variables
 
 Create `backend/.env`:
 
 ```env
-DATABASE_URL=postgresql+asyncpg://<user>:<password>@<host>/<db>
+DATABASE_URL=postgresql+asyncpg://<user>:<password>@<host>:<port>/<db>
 SUPABASE_URL=https://<project>.supabase.co
 SUPABASE_ANON_KEY=<anon-key>
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
-JWT_SECRET=<your-secret>
+SUPABASE_JWT_SECRET=<jwt-secret-from-supabase-settings>
 ANTHROPIC_API_KEY=<your-key>
+
+# Optional: set to true to skip JWT validation in local dev.
+# Keep false when testing the auth flow.
+DEV_BYPASS_AUTH=false
 ```
 
-Create `frontend/.env.local`:
+The frontend defaults to `http://localhost:8000` for the backend. To point at a different host, create `frontend/.env.local`:
 
 ```env
-NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=https://your-backend-host
 ```
 
 ### Backend
 
 ```bash
 cd backend
-uv sync
-alembic upgrade head
-uvicorn app.main:app --reload --port 8000
+uv sync --extra dev          # installs runtime + test deps
+alembic upgrade head         # applies schema migrations
+uv run uvicorn app.main:app --reload --port 8000
 ```
 
 ### Frontend
 
+In a second terminal:
+
 ```bash
 cd frontend
 npm install
-npm run dev     # dev server on :3000
+npm run dev                  # dev server on :3000
 ```
+
+Open `http://localhost:3000`.
 
 ---
 
 ## AI Agent Architecture
 
-Three agents run during a session. Each agent invocation is fully logged (agentId, input, output, latency, model version, timestamp) for the LLM-as-judge pipeline.
+Three agents run during a session. Each agent invocation is logged (agent id, input, output, latency, model version, timestamp) for the LLM-as-judge pipeline.
 
 ### Question Generation Agent
 - **Trigger:** Session start
-- **Inputs:** interview type, role, difficulty, question count, previously seen question IDs
+- **Inputs:** interview type, role, difficulty, question count, previously seen question ids
 - **Output:** Array of question objects with text, type, role, difficulty, and tags
-- **Behavior:** Generates role-specific questions via Claude. Does not repeat questions seen in the last 5 sessions.
 
 ### Answer Evaluation Agent
 - **Trigger:** Candidate submits an answer
@@ -145,7 +157,7 @@ Three agents run during a session. Each agent invocation is fully logged (agentI
 ### Feedback Synthesis Agent
 - **Trigger:** Runs in parallel with the Evaluation Agent via `asyncio.gather()`
 - **Inputs:** question, answer, evaluation scores, reasoning
-- **Output:** 2-3 sentence summary, 1-3 sentence behavioral feedback per dimension, one concrete improvement suggestion
+- **Output:** 2–3 sentence summary, 1–3 sentence behavioral feedback per dimension, one concrete improvement suggestion
 
 ```
 Route Handler → Service → asyncio.gather(
@@ -159,75 +171,32 @@ Route Handler → Service → asyncio.gather(
 ## Scoring System
 
 - **Dimension scores:** integers 1–10
-- **Composite score:** weighted average using the active `RubricVersion` for the session's role
-- **Dual scores:** both `ai_score` and `coach_score` are stored. Coach score is authoritative when present. Neither is ever overwritten or deleted.
-- **Rubric changes** apply to new sessions only — never retroactively.
-
----
-
-## Coach Override & LLM-as-Judge
-
-When a Coach overrides AI scores, the override (with justification) becomes a labeled ground-truth record. After review completion, an async LLM-as-judge job runs:
-
-1. Inputs original question, candidate answer, AI scores + reasoning, Coach scores + justification to Claude
-2. Claude outputs: `agreement` (bool per dimension), `confidence` (0.0–1.0), `reasoning` (string)
-3. Results feed the Admin Evaluation Dashboard (agreement rate, score drift, override rate)
+- **Composite score:** weighted average using the active `RubricVersion` for the session's role; falls back to equal 0.2 weights when none is configured
+- **Dual scores:** both `ai_score` and `coach_score` are stored. Coach score is authoritative when present. Neither is ever overwritten or deleted — overrides supersede, they do not replace.
+- **Rubric weight changes** apply to new sessions only, never retroactively.
 
 ---
 
 ## API Overview
 
-All endpoints are prefixed `/api/v1` and require `Authorization: Bearer <token>` except `/health` and `/auth/*`.
+All endpoints are under `/api/v1`. Every route except `/health`, `/auth/register`, and `/auth/login` requires `Authorization: Bearer <token>`.
 
-| Group | Routes |
-|---|---|
-| Auth | `POST /auth/register`, `POST /auth/login`, `GET /auth/me` |
-| Sessions | `POST /sessions`, `GET /sessions/:id`, `POST /sessions/:id/questions/:qid/answer`, `GET /sessions/:id/feedback`, `GET /sessions/history` |
-| Coach | `GET /coach/queue`, `POST /coach/sessions/:id/overrides`, `POST /coach/sessions/:id/comment`, `PATCH /coach/sessions/:id/complete` |
-| Admin | `GET/POST /admin/questions`, `GET/POST /admin/rubrics`, `GET /admin/evals/dashboard` |
-| Health | `GET /health` |
+| Group | Route | Notes |
+|---|---|---|
+| Health | `GET /health` | Liveness probe |
+| Auth | `POST /auth/register` | Accepts optional `role: "candidate" \| "coach"` (default candidate). `admin` is rejected with 422. |
+| Auth | `POST /auth/login` | Returns a JWT |
+| Auth | `GET /auth/me` | Returns the authenticated user's id, email, role, created_at |
+| Sessions (candidate) | `POST /sessions` | Creates a session + generates questions |
+| Sessions (candidate) | `GET /sessions/history` | Candidate's completed/reviewed sessions |
+| Sessions (candidate) | `GET /sessions/trends` | Composite + per-dimension trend over the last 10 sessions |
+| Sessions (candidate) | `GET /sessions/{id}` | Scoped to the authenticated candidate |
+| Sessions (candidate) | `POST /sessions/{id}/questions/{qid}/answer` | Submit answer; runs eval + feedback agents in parallel |
+| Coach | `GET /coach/sessions` | Queue of completed sessions awaiting review |
+| Coach | `GET /coach/sessions/{id}` | Full session detail; not scoped by candidate_id |
+| Coach | `POST /coach/sessions/{id}/questions/{qid}/score` | Submit override scores + justification; flips session to `reviewed` |
 
----
-
-## Testing
-
-### Backend
-
-```bash
-# All tests with coverage
-pytest backend/app/tests/ -v --cov=app
-
-# Single file
-pytest backend/app/tests/test_session_service.py -v
-
-# Lint
-ruff check backend/
-```
-
-Coverage target: >80% on all `services/` and `agents/` modules.  
-Pattern: **Red → Green → Refactor** — tests are written before implementation.
-
-### Frontend
-
-```bash
-cd frontend
-npm test          # Jest + RTL
-npm run lint      # ESLint + Prettier check
-npm run build     # production build check
-```
-
----
-
-## Security
-
-- All secrets via environment variables. No credentials in the codebase.
-- JWT validation on every protected endpoint via `get_current_user` dependency.
-- Role-based access: Candidates, Coaches, and Admins see only their authorized views.
-- All DB access through SQLAlchemy ORM — no raw SQL strings.
-- User input is sanitized before passing to any LLM prompt.
-- CORS origins are explicitly allowlisted.
-- CI gates: [Gitleaks](https://github.com/gitleaks/gitleaks) secrets scan, `npm audit --audit-level=critical`, and a security reviewer agent on new routes.
-- Security policy addresses OWASP Top 10 — see [`docs/security.md`](docs/security.md).
+Coach routes return `403 Forbidden` for users whose role is not `coach` or `admin`.
 
 ---
 
@@ -238,6 +207,100 @@ CREATED → IN_PROGRESS → COMPLETED → REVIEWED
                                 ↘ ABANDONED (auto, after 48h idle)
 ```
 
+- `CREATED` — session record exists, no answers yet
+- `IN_PROGRESS` — at least one answer submitted
+- `COMPLETED` — all questions answered, appears on the coach queue
+- `REVIEWED` — a coach has submitted at least one override; drops off the queue
+
+---
+
+## Testing
+
+### Backend
+
+```bash
+cd backend
+
+# Full suite with coverage
+uv run pytest app/tests/ -v --cov=app
+
+# Single file
+uv run pytest app/tests/test_session_service.py -v
+
+# Lint
+uv run ruff check .
+```
+
+Coverage target: >80% on all `services/` and `agents/` modules.
+Discipline: **Red → Green → Refactor** — failing tests are committed before the implementation that makes them pass. This is visible in the git history (`test:` commits precede their matching `feat:` commits).
+
+### Frontend
+
+```bash
+cd frontend
+npm test                     # Jest + React Testing Library
+npm run lint                 # ESLint + Prettier
+npx tsc --noEmit             # type check
+npm run build                # production build
+```
+
+### End-to-end
+
+```bash
+cd frontend
+npx playwright test          # requires the backend + frontend dev servers running
+```
+
+---
+
+## Repository Structure
+
+```
+/
+├── frontend/                  # Next.js app
+│   ├── app/
+│   │   ├── (candidate)/       # Candidate-facing routes (dashboard, new session, interview, detail)
+│   │   ├── (coach)/           # Coach-facing routes (review queue, session review)
+│   │   ├── login/
+│   │   └── register/          # Accepts ?role=coach
+│   ├── components/
+│   │   ├── session/           # Candidate session UI (cards, charts, detail, setup, live interview)
+│   │   └── coach/             # CoachScoreForm
+│   ├── lib/
+│   │   ├── api/               # Typed REST clients (auth, sessions, coach)
+│   │   ├── auth/              # AuthContext — stores token + user, /auth/me hydration, auto-logout on 401
+│   │   └── types/
+│   └── __tests__/             # Jest + RTL
+├── backend/
+│   ├── app/
+│   │   ├── api/v1/            # auth.py, sessions.py, coach.py, health.py
+│   │   ├── agents/            # question_generation, answer_evaluation, feedback_synthesis, logging_utils
+│   │   ├── models/            # SQLAlchemy ORM models
+│   │   ├── schemas/           # Pydantic request/response schemas
+│   │   ├── services/          # Business logic (session, coach, auth)
+│   │   ├── core/              # config, db, security (JWT)
+│   │   └── tests/             # pytest
+│   ├── alembic/               # Database migrations
+│   └── pyproject.toml
+├── docs/                      # PRD, architecture, security, testing, commands, sprints
+├── tasks/                     # todo.md, lessons.md
+└── CLAUDE.md                  # Instructions for AI-assisted development
+```
+
+---
+
+## Security
+
+- All secrets are read from environment variables. No credentials in source.
+- JWT validation on every protected route via the `get_current_user` FastAPI dependency.
+- Role-based access: `/api/v1/coach/*` requires `role` ∈ {`coach`, `admin`}. Candidates receive `403`.
+- Candidates can only read sessions they own — `get_session_detail` scopes by `candidate_id`.
+- All database access goes through SQLAlchemy ORM. Raw SQL is never constructed from user input.
+- User input is sanitized before being passed to any LLM prompt.
+- CORS origins are explicitly allowlisted.
+- CI gates: [Gitleaks](https://github.com/gitleaks/gitleaks) secrets scan, `npm audit --audit-level=critical`, and a dedicated security reviewer agent on new routes.
+- Full OWASP Top 10 coverage documented in [`docs/security.md`](docs/security.md).
+
 ---
 
 ## Documentation
@@ -247,6 +310,9 @@ CREATED → IN_PROGRESS → COMPLETED → REVIEWED
 | [`docs/PRD.md`](docs/PRD.md) | Full product requirements, user stories, acceptance criteria |
 | [`docs/architecture.md`](docs/architecture.md) | Architecture decisions and patterns |
 | [`docs/security.md`](docs/security.md) | OWASP coverage, CI security gates |
-| [`docs/testing.md`](docs/testing.md) | Testing strategy and patterns |
-| [`CLAUDE.md`](CLAUDE.md) | AI agent development instructions |
+| [`docs/testing.md`](docs/testing.md) | Testing strategy and TDD conventions |
+| [`docs/conventions.md`](docs/conventions.md) | Code style and naming conventions |
+| [`docs/commands.md`](docs/commands.md) | All dev commands in one place |
+| [`docs/demo_script.md`](docs/demo_script.md) | Walkthrough script for the demo video |
+| [`CLAUDE.md`](CLAUDE.md) | Instructions for AI-assisted development |
 | [`tasks/todo.md`](tasks/todo.md) | Current sprint task tracking |


### PR DESCRIPTION
## Summary
Follow-up to #31 — adds a TA-facing quick demo section at the top of the README so reviewers can create a coach account and walk the full review flow without reading the codebase.

## Why now
During demo prep I hit two frustrations that this doc fixes:
- It was not obvious how to register a coach account (the hidden `/register?role=coach` URL)
- The README's API table and env vars had drifted from what actually ships on main (wrong route names, wrong env var names, references to unimplemented admin endpoints)

## What changed
- **New "For Reviewers / TAs" section** at the top of the README covering:
  - Creating a candidate via `/register`
  - Creating a coach via `/register?role=coach` with the purple badge as visual confirmation
  - Full coach review flow (queue → detail → override → session flips to `reviewed`)
  - Extras worth trying (role-based login redirect, stale-token auto-logout, cross-role guard)
- **Fixed stale references:**
  - `JWT_SECRET` → `SUPABASE_JWT_SECRET` (matches `core/config.py`)
  - Added `DEV_BYPASS_AUTH` with guidance
  - Model name `claude-sonnet-4-20250514` → `claude-sonnet-4-6`
  - Rewrote the API table to match real routes; removed nonexistent endpoints (`/coach/queue`, `/coach/sessions/:id/overrides`, `/coach/sessions/:id/comment`, all `/admin/*`) and added `GET /auth/me` and `GET /coach/sessions/{id}` that shipped in #31
  - Backend test commands prefixed with `uv run`
  - Added Playwright e2e command
  - Docs index now lists `conventions.md`, `commands.md`, `demo_script.md`

## Test plan
- [x] README renders correctly in GitHub preview
- [x] All route names in the API table match `backend/app/api/v1/*.py`
- [x] All env var names match `backend/app/core/config.py`
- [x] All referenced `docs/*.md` files exist in the repo

## C.L.E.A.R. Review Checklist
- [x] **Correct** — every route name and env var was verified against the actual code
- [x] **Lean** — docs-only change, no code churn
- [x] **Explicit** — TA walkthrough is numbered, step-by-step, with the expected visual state at each step ("purple badge", "/review", "session flips to reviewed")
- [x] **Accurate** — removed references to admin endpoints that do not exist yet
- [x] **Reversible** — single-file docs change

## AI Disclosure
~85% AI-generated (Claude Opus 4.7 via Claude Code)
Human review: confirmed the coach-registration framing would be clear to a TA coming in cold, cross-checked route names against `backend/app/api/v1/*`, and decided to keep the existing `docs/PRD.md` link rather than introducing a new top-level index
Tool: Claude Code (claude-opus-4-7)